### PR TITLE
changed sulfate component

### DIFF
--- a/src/SulphateForcing.jl
+++ b/src/SulphateForcing.jl
@@ -31,7 +31,7 @@ function run_timestep(s::SulphateForcing, tt::Int64)
         # Eq.17 from Hope (2006) - sulfate flux
         v.sfx_sulphateflux[tt,rr] = v.se_sulphateemissions[tt,rr] / p.area[rr]
         # Update for Eq. 18 from Hope (2009) - sulfate radiative forcing effect
-        bigSFD0 = p.d_sulphateforcingbase * bigSFX0[rr] / sum(bigSFX0)
+        bigSFD0 = p.d_sulphateforcingbase * bigSFX0[rr] / sum(bigSFX0) #check with Chris Hope - this contradicts documentation for PAGE2009
         fsd_term = bigSFD0 * v.sfx_sulphateflux[tt,rr] / bigSFX0[rr]
         fsi_term = p.ind_slopeSEforcing_indirect/log(2) * log((p.nf_naturalsfx[rr] + v.sfx_sulphateflux[tt, rr]) / p.nf_naturalsfx[rr])
 


### PR DESCRIPTION
This change contradicts the documentation, but I think it makes sense if you look at what is going on with each equation. 
fsd(i,r) = FSD(0,r)\* sfx(i,r)/SFX(0,r)  - fsd(i,r) is the direct sulfate forcing in the base year coming from region r scaled by the change in sulfate flux. This means that if you sum FSD(0,r) over regions, you should get the baseline direct sulfate flux of -0.47. But instead right now we get -5.1. 
For this to work FSD(0,r) = D*SFX(0,r)/ SFX_G(0) only works if SFX_G(0)=sum(SFX(0,r)), not the "area weighted average of the regional base year sulphate fluxes" as given in the documentation.  

This change gives land temperatures that I think look pretty sensible (e.g. 0.8 in 2009), though there is still an issue that CO2 concentrations drop in the first couple years. 

Does this make any sense at all? 
