### PR TITLE
Handle of relative paths in `readpagedata`

### DIFF
--- a/src/load_parameters.jl
+++ b/src/load_parameters.jl
@@ -25,6 +25,11 @@ function checktimeorder(model::Model, times, file)
 end
 
 function readpagedata(model::Model, filepath::AbstractString)
+    # Handle relative paths
+    if filepath[1] ∉ ['.', '/'] && !isfile(filepath)
+        filepath = joinpath(dirname(@__FILE__), "..", filepath)
+    end
+
     content = readlines(filepath)
 
     firstline = chomp(content[1])


### PR DESCRIPTION
If a filename passed to `readpagedata` does not start with `.` or `/`, and if it does not refer to a relative path that exists from the current directory, `readpagedata` will look for the file instead relative to the repository root.

So, to access files in `data/`, you can say `readpagedata("data/...")`, in any file.

If you are in `test`, you can refer to data in `validationtests` either with `readpagedata("validationtests/...")` or `readpagedata("test/validationtests/...").  The latter is recommended though, because the former will only work if you have set the current directory to `test` beforehand.