### PR TITLE
Standardize units for GDP_per_cap_focus_0_FocusRegionEU parameter

### DIFF
--- a/src/components/Discontinuity.jl
+++ b/src/components/Discontinuity.jl
@@ -12,7 +12,7 @@
 
   igdpeqdis_eqdiscimpact=Variable(index=[time,region], unit="%")
   rgdp_per_cap_NonMarketRemainGDP=Parameter(index=[time,region], unit="\$/person")
-  GDP_per_cap_focus_0_FocusRegionEU = Parameter(unit="unitless", default=27934.244777382406)
+  GDP_per_cap_focus_0_FocusRegionEU = Parameter(unit="\$/person", default=27934.244777382406)
   ipow_incomeexponent=Parameter(unit="unitless", default=-0.13333333333333333)
 
   igdp_realizeddiscimpact=Variable(index=[time,region], unit="%")

--- a/src/components/MarketDamages.jl
+++ b/src/components/MarketDamages.jl
@@ -20,7 +20,7 @@
     ipow_MarketIncomeFxnExponent =Parameter(default=-0.13333333333333333)
     iben_MarketInitialBenefit=Parameter(default=.1333333333333)
     tcal_CalibrationTemp = Parameter(default=3.)
-    GDP_per_cap_focus_0_FocusRegionEU = Parameter(default=27934.244777382406)
+    GDP_per_cap_focus_0_FocusRegionEU = Parameter(unit="\$/person", default=27934.244777382406)
 
     #impact variables
     isatg_impactfxnsaturation = Parameter(unit="unitless")

--- a/src/components/SLRDamages.jl
+++ b/src/components/SLRDamages.jl
@@ -23,7 +23,7 @@
     pow_SLRImpactFxnExponent=Parameter(default=0.7333333333333334)
     iben_SLRInitialBenefit=Parameter(default=0.00)
     scal_calibrationSLR = Parameter(default=0.5)
-    GDP_per_cap_focus_0_FocusRegionEU = Parameter(default=27934.244777382406)
+    GDP_per_cap_focus_0_FocusRegionEU = Parameter(unit="\$/person", default=27934.244777382406)
 
     #component variables
     cons_percap_aftercosts = Variable(index=[time, region], unit = "\$/person")


### PR DESCRIPTION
I ran into this because of the scenario choice component that I'm adding for the IWG versions, where four different components with this parameter will connect to the value in the IWGScenarioChoice component. I was trying to be good about keeping the unit definitions, and noticed that this one was different across components. 

This commit changes the units in Discontinuity, MarketDamages, and SLRDamages to match the units of "$/person" in the NonMarketDamages component.

If this update isn't desired, though, I can get away with using the `ignoreunits` flag when making my connections, but wanted to bring this up in case it was just a mistake to have different units across components.