### PR TITLE
standard get_model and compute_scc API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ There is an additional function for computing the SCC that also returns the Marg
 using Mimi
 using MimiPAGE2009
 
-result = MimiPAGE2009.compute_scc_mm(year=2030, eta=0, prtp=2.5)
+result = MimiPAGE2009.compute_scc_mm(year=2030, eta=0, prtp=0.025)
 
 result.scc  # returns the computed SCC value
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,52 @@ pkg> add Mimi
 ## Running the Model
 The model uses the Mimi framework and it is highly recommended to read the Mimi documentation first to understand the code structure. For starter code on running the model just once, see the code in the file `examples/main.jl`.
 
+The basic way to access a copy of the default MimiPAGE2009 model is the following:
+```
+using MimiPAGE2009
+
+m = MimiPAGE2009.get_model()
+run(m)
+```
+
+## Calculating the Social Cost of Carbon
+
+Here is an example of computing the social cost of carbon with MimiPAGE2009. Note that the units of the returned value are dollars $/ton CO2.
+```
+using Mimi
+using MimiPAGE2009
+
+# Get the social cost of carbon in year 2020 from the default MimiPAGE2009 model:
+scc = MimiPAGE2009.compute_scc(year = 2020)
+
+# You can also compute the SCC from a modified version of a MimiPAGE2009 model:
+m = MimiPAGE2009.get_model()    # Get the default version of the MimiPAGE2009 model
+update_param!(m, :tcr_transientresponse, 3)    # Try a higher transient climate response value
+scc = MimiPAGE2009.compute_scc(m, year=2020)    # compute the scc from the modified model by passing it as the first argument to compute_scc
+```
+The first argument to the `compute_scc` function is a MimiPAGE2009 model, and it is an optional argument. If no model is provided, the default MimiPAGE2009 model will be used. 
+There are also other keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
+```
+compute_scc(m = get_model(),  # if no model provided, will use the default MimiPAGE2009 model
+    year = nothing,  # user must specify an emission year for the SCC calculation
+    eta = nothing,  # eta parameter for ramsey discounting representing the elasticity of marginal utility. If nothing is provided, the value of parameter :emuc_utiliyconvexity in the MimiPAGE2009 model is unchanged, which has a default value of 1.1666666667.
+    prtp = nothing  # pure rate of time preference parameter used for discounting. If nothing is provided, the value of parameter :ptp_timepreference in the MimiPAGE2009 model is unchanged, which has a default value of 1.0333333333%.
+)
+```
+There is an additional function for computing the SCC that also returns the MarginalModel that was used to compute it. It returns these two values as a NamedTuple of the form (scc=scc, mm=mm). The same keyword arguments from the `compute_scc` function are available for the `compute_scc_mm` function. Example:
+```
+using Mimi
+using MimiPAGE2009
+
+result = MimiPAGE2009.compute_scc_mm(year=2030, eta=0, prtp=2.5)
+
+result.scc  # returns the computed SCC value
+
+result.mm   # returns the Mimi MarginalModel
+
+marginal_temp = result.mm[:ClimateTemperature, :rt_realizedtemperature]  # marginal results from the marginal model can be accessed like this
+```
+
 ## References
 
 Hope, Chris. [The PAGE09 integrated assessment model: A technical description](https://www.jbs.cam.ac.uk/fileadmin/user_upload/research/workingpapers/wp1104.pdf). *Cambridge Judge Business School Working Paper*, 2011, 4(11). 

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -65,7 +65,7 @@ pkg> add MimiPAGE2009
 
 To run the model, run the `main.jl` file in the examples folder. This
 runs the deterministic version of Mimi-PAGE with central parameter
-estimates. The `getpage` function used in that file create the
+estimates. The `MimiPAGE209.get_model` function used in that file create the
 initialized PAGE model. You can print the model, by typing `m`, which
 returns a list of components and each of their incoming parameters and
 outgoing variables. Results can be viewed by running `m[:ComponentName, :VariableName]` 

--- a/docs/src/model-structure.md
+++ b/docs/src/model-structure.md
@@ -83,7 +83,7 @@ The components in this portion of Mimi-PAGE include:
 ### Functional Components of Mimi-PAGE
 
 The following scripts assist in the actual running of Mimi-Page, and are further elaborated in the technical user guide.
-- getpagefunction.jl
+- MimiPAGE2009.jl
 - load_parameters.jl
 - main_model.jl
 - mctools.jl

--- a/docs/src/technicaluserguide.md
+++ b/docs/src/technicaluserguide.md
@@ -94,7 +94,7 @@ where we can set exogenous parameters imported from a CSV file.  In this case su
 a step is not needed.
 
 
-In the `src/getpagefunction.jl` file, you will find code that sends variables between components. For example,
+In the `src/MimiPAGE2009.jl` file, you will find code that sends variables between components. For example,
 
 ```
 CO2forcing[:c_CO2concentration] = CO2cycle[:c_CO2concentration] # incoming = outgoing.

--- a/examples/main.jl
+++ b/examples/main.jl
@@ -1,6 +1,6 @@
 using Mimi
 using MimiPAGE2009
 
-m = getpage()
+m = MimiPAGE2009.get_model()
 run(m)
 explore(m)

--- a/src/MimiPAGE2009.jl
+++ b/src/MimiPAGE2009.jl
@@ -9,6 +9,8 @@ include("utils/mctools.jl")
 
 include("mcs.jl")
 
+include("compute_scc.jl")
+
 include("components/CO2emissions.jl")
 include("components/CO2cycle.jl")
 include("components/CO2forcing.jl")
@@ -211,7 +213,7 @@ function initpage(m::Model, policy::String="policy-a")
     set_leftover_params!(m, p)
 end
 
-function getpage(policy::String="policy-a")
+function get_model(policy::String="policy-a")
     m = Model()
     set_dimension!(m, :time, [2009, 2010, 2020, 2030, 2040, 2050, 2075, 2100, 2150, 2200])
     set_dimension!(m, :region, ["EU", "USA", "OECD","USSR","China","SEAsia","Africa","LatAmerica"])
@@ -223,5 +225,7 @@ function getpage(policy::String="policy-a")
 
     return m
 end
+
+getpage = get_model
 
 end

--- a/src/compute_scc.jl
+++ b/src/compute_scc.jl
@@ -1,0 +1,129 @@
+page_years = [2009, 2010, 2020, 2030, 2040, 2050, 2075, 2100, 2150, 2200]
+page_year_0 = 2008
+
+function getpageindexfromyear(year)
+    i = findfirst(isequal(year), page_years)
+    if i == 0
+        error("Invalid PAGE year: $year.")
+    end 
+    return i 
+end
+
+function getperiodlength(year)      # same calculations made for yagg_periodspan in the model
+    i = getpageindexfromyear(year)
+
+    if year==page_years[1]
+        start_year = page_year_0
+    else
+        start_year = page_years[i - 1]
+    end
+
+    if year == page_years[end]
+        last_year = page_years[end]
+    else
+        last_year = page_years[i + 1]
+    end
+
+    return (last_year - start_year) / 2
+end
+
+@defcomp PAGE_marginal_emissions begin 
+    er_CO2emissionsgrowth = Variable(index=[time,region], unit = "%")
+    marginal_emissions_growth = Parameter(index=[time,region], unit = "%", default = zeros(10,8))
+    function run_timestep(p, v, d, t)
+        if is_first(t)
+            v.er_CO2emissionsgrowth[:, :] = p.marginal_emissions_growth[:, :]
+        end
+    end
+end
+
+"""
+compute_scc(m::Model = get_model(); year::Union{Int, Nothing} = nothing, eta::Union{Float64, Nothing} = nothing, prtp::Union{Float64, Nothing} = nothing)
+
+Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiPAGE2009 model. 
+If no model is provided, the default model from MimiPAGE2009.get_model() is used.
+Discounting scheme can be specified by the `eta` and `prtp` parameters, which will update the values of emuc_utilitiyconvexity and ptp_timepreference in the model. 
+If no values are provided, the discount factors will be computed using the default PAGE values of emuc_utilitiyconvexity=1.1666666667 and ptp_timepreference=1.0333333333.
+
+TODO:
+- I did not allow for last_year keyword
+- Should we allow eta and prpt keywords, even though they are model parameters and I have to update the provided model with them? should I warn in this case?
+- note that prtp has to be specified as a percent (i.e. 3 instead of 0.03)
+- SCC values for later years are lower, because I think td_totaldiscountedimpacts are discounted back to today instead of the SCC year. Should we change this?
+"""
+function compute_scc(m::Model = get_model(); year::Union{Int, Nothing} = nothing, eta::Union{Float64, Nothing} = nothing, prtp::Union{Float64, Nothing} = nothing)
+    year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2020)`.") : nothing
+    !(year in page_years) ? error("Cannot compute the scc for year $year, year must be within the model's time index $page_years.") : nothing 
+
+    eta == nothing ? nothing : update_param!(m, :emuc_utilityconvexity, eta)
+    prtp == nothing ? nothing : update_param!(m, :ptp_timepreference, prtp)
+
+    mm = get_marginal_model(m, year=year)   # Returns a marginal model that has already been run
+    scc = mm[:EquityWeighting, :td_totaldiscountedimpacts] / 100000
+
+    return scc
+end
+
+"""
+compute_scc_mm(m::Model = get_model(); year::Union{Int, Nothing} = nothing, eta::Union{Float64, Nothing} = nothing, prtp::Union{Float64, Nothing} = nothing)
+
+Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
+Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiPAGE2009 model. 
+If no model is provided, the default model from MimiPAGE2009.get_model() is used.
+Discounting scheme can be specified by the `eta` and `prtp` parameters, which will update the values of emuc_utilitiyconvexity and ptp_timepreference in the model. 
+If no values are provided, the discount factors will be computed using the default PAGE values of emuc_utilitiyconvexity=1.1666666667 and ptp_timepreference=1.0333333333.    
+"""
+function compute_scc_mm(m::Model = get_model(); year::Union{Int, Nothing} = nothing, eta::Union{Float64, Nothing} = nothing, prtp::Union{Float64, Nothing} = nothing)
+    year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2020)`.") : nothing
+    !(year in page_years) ? error("Cannot compute the scc for year $year, year must be within the model's time index $page_years.") : nothing 
+
+    eta == nothing ? nothing : update_param!(m, :emuc_utilityconvexity, eta)
+    prtp == nothing ? nothing : update_param!(m, :ptp_timepreference, prtp)
+
+    mm = get_marginal_model(m, year=year)   # Returns a marginal model that has already been run
+    scc = mm[:EquityWeighting, :td_totaldiscountedimpacts] / 100000
+
+    return (scc = scc, mm = mm)
+end
+
+"""
+get_marginal_model(m::Model = get_model(); year::Union{Int, Nothing} = nothing)
+
+Returns a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of CO2 in year `year`.
+If no Model m is provided, the default model from MimiPAGE2009.get_model() is used as the base model.
+
+Notes:
+- the marginal model values haven't been divided by 10^5 to reflect the size of the pulse. this is true for FUND and DICE too at this point.
+- Returns a MarginalModel that has already been run, because of the need to run the base model before being able to calculate what the marginal emission rate needs to be in the marginal model.
+- This is how the IWG did the pulse and added marginal emissions. I'm not sure if there's a different example of doing this in PAGE that I should use instead.
+"""
+function get_marginal_model(m::Model = get_model(); year::Union{Int, Nothing} = nothing)
+    year === nothing ? error("Must specify an emission year. Try `get_marginal_model(m, year=2020)`.") : nothing
+    !(year in page_years) ? error("Cannot add marginal emissions in $year, year must be within the model's time index $page_years.") : nothing
+
+    mm = create_marginal_model(m)
+
+    add_comp!(mm.marginal, PAGE_marginal_emissions, :marginal_emissions; before = :co2emissions)
+    connect_param!(mm.marginal, :co2emissions=>:er_CO2emissionsgrowth, :marginal_emissions=>:er_CO2emissionsgrowth)
+    connect_param!(mm.marginal, :AbatementCostsCO2=>:er_emissionsgrowth, :marginal_emissions=>:er_CO2emissionsgrowth)
+
+    i = getpageindexfromyear(year) 
+
+    # Base model
+    run(mm.base)
+    base_glob0_emissions = mm.base[:co2cycle, :e0_globalCO2emissions]
+    er_co2_a = mm.base[:co2emissions, :er_CO2emissionsgrowth][i, :]
+    e_co2_g = mm.base[:co2emissions, :e_globalCO2emissions]  
+
+    # Calculate pulse 
+    ER_SCC = 100 * -100000 / (base_glob0_emissions * getperiodlength(year))
+    pulse = er_co2_a - ER_SCC * (er_co2_a/100) * (base_glob0_emissions / e_co2_g[i])
+    marginal_emissions_growth = copy(mm.base[:co2emissions, :er_CO2emissionsgrowth])
+    marginal_emissions_growth[i, :] = pulse
+
+    # Marginal emissions model
+    update_param!(mm.marginal, :marginal_emissions_growth, marginal_emissions_growth)
+    run(mm.marginal)
+
+    return mm
+end

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -237,7 +237,7 @@ function do_monte_carlo_runs(samplesize::Int; output_dir::String = joinpath(@__D
         mcs = getsim()
         
         # get a model
-        m = getpage()
+        m = get_model()
         run(m)
 
         # Generate trial data for all RVs and save to a file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,4 +51,6 @@ include("test_TotalForcing.jl")
 include("test_mcs.jl")
 include("contrib/test_taxeffect.jl") 
 
+include("test_standard_api.jl")
+
 end

--- a/test/test_mainmodel.jl
+++ b/test/test_mainmodel.jl
@@ -2,7 +2,7 @@ using Test
 
 Mimi.reset_compdefs()
 
-m = getpage()
+m = MimiPAGE2009.get_model()
 run(m)
 
 while m[:Discontinuity,:occurdis_occurrencedummy] != [0.,0.,0.,0.,0.,0.,0.,0.,0.,1.]

--- a/test/test_mainmodel_policyb.jl
+++ b/test/test_mainmodel_policyb.jl
@@ -2,10 +2,10 @@ using Test
 
 Mimi.reset_compdefs()
 
-m = getpage()
+m = MimiPAGE2009.get_model()
 run(m)
 
-m = getpage("policy-b")
+m = MimiPAGE2009.get_model("policy-b")
 run(m)
 
 while m[:Discontinuity,:occurdis_occurrencedummy] != [0.,0.,0.,0.,0.,0.,0.,0.,0.,0.]

--- a/test/test_standard_api.jl
+++ b/test/test_standard_api.jl
@@ -1,0 +1,29 @@
+using Test
+using Mimi
+
+@testset "Standard API" begin 
+
+# Test that the function does not error and returns a valid value
+scc1 = MimiPAGE2009.compute_scc(year=2020)
+@test scc1 isa Float64
+
+# Test that a higher discount rate makes a lower scc value
+scc2 = MimiPAGE2009.compute_scc(year=2020, eta=0., prtp=3.)
+@test scc2 < scc1   
+
+# Test with a modified model
+m = MimiPAGE2009.get_model()
+update_param!(m, :tcr_transientresponse, 3)
+scc3 = MimiPAGE2009.compute_scc(m, year=2020)
+@test scc3 > scc1
+
+# Test get_marginal_model
+mm = MimiPAGE2009.get_marginal_model(year = 2040)
+mm[:ClimateTemperature, :rt_realizedtemperature]
+
+# Test compute_scc_mm
+result = MimiPAGE2009.compute_scc_mm(year=2050)
+@test result.scc < scc1
+@test result.mm isa Mimi.MarginalModel
+
+end

--- a/test/test_standard_api.jl
+++ b/test/test_standard_api.jl
@@ -8,7 +8,7 @@ scc1 = MimiPAGE2009.compute_scc(year=2020)
 @test scc1 isa Float64
 
 # Test that a higher discount rate makes a lower scc value
-scc2 = MimiPAGE2009.compute_scc(year=2020, eta=0., prtp=3.)
+scc2 = MimiPAGE2009.compute_scc(year=2020, eta=0., prtp=0.03)
 @test scc2 < scc1   
 
 # Test with a modified model


### PR DESCRIPTION
Questions/notes:
- I perturbed the marginal emissions in the manner that the IWG did in Excel. You run the base model first, because you need to run it in order to calculate what the marginal emissions growth needs to be in the marginal model. So the actual value you are modifying in the marginal model is emissions growth. I'm not sure if there is different code somewhere with an example of how to add marginal emissions in PAGE, but this is what I did for now.
- Then for actually calculating the SCC, I used the `td_totaldiscountedimpacts` from EquityWeighting component and just subtracted this value from the base and marginal models, so all of the discounting and weighting happens internally to the model.
- I did not allow for `last_year` keyword argument, because the discounting and aggregation over years happens within the model
- I did allow for `eta` and `prtp` keywords in `compute_scc`, however this means that if the user provides these values, the `compute_scc` function actually updates the values of `emuc_utilitiyconvexity` and `ptp_timepreference` within the model. This is explained in the docstring and the README, but should we issue a warning if the user provides a modified model and also provides values for `eta` and `prtp`, that warns that we are updating these parameters in the provided model?
- Also: the prtp value in page is accepted as a percentage, i.e. the provided value should be 3.0 rather than 0.03 if the user wants 3%. Should we change this so that the keyword argument expects values like 0.03, and then we multiply by 100 before setting the `:ptp_timepreference` parameter, or should we leave it as is?
- One important thing I realized that is also relevant for MimiFUND and MimiDICE2010 is that the `get_marginal_model` function returns a MarginalModel that has marginal affects for larger than a one ton pulse of emissions. We divide back out by the total pulse size when doing the SCC calculations, but if the user accesses other marginal results from the MarginalModel (like temperature), it would reflect a larger pulse. Do we want to change this so that the MarginalModel uses the built in delta value equal to the pulse size?
- I'm not sure using the `td_totaldiscountedimpacts` out of the EquityWeighting component is actually the right way to go for calculating the SCC, because I think it's discounted all the way back to the present day, rather than to the SCC year. For example, later years actually have lower values when calculated this way:
```
julia> using MimiPAGE2009
julia> [MimiPAGE2009.compute_scc(year=y) for y in 2010:10:2050]
5-element Array{Float64,1}:
 52.326389484803975
 50.40718696472138
 46.18869923466474
 41.7423347017315
 36.36017887025624
```
The IWG did this differently where they took this value, then divided back out the discount factor that was used, and then rediscounted it for the SCC year. This results in later years having higher discount values. I'm not sure which way is "right"