### PR TITLE
Add Ramsey discounting option without equity weighting

### DIFF
--- a/src/compute_scc.jl
+++ b/src/compute_scc.jl
@@ -42,7 +42,7 @@ end
 
 @defcomp ExtraEmissions begin
     e_globalCO2emissions = Parameter(index=[time],unit="Mtonne/year")
-    pulse_size = Parameter()
+    pulse_size = Parameter(unit="Mtonne CO2")
     pulse_year = Parameter()
     e_globalCO2emissions_adjusted = Variable(index=[time],unit="Mtonne/year")
 
@@ -74,7 +74,7 @@ and ptp_timepreference in the model. If no values are provided, the discount fac
 PAGE values of emuc_utilitiyconvexity=1.1666666667 and ptp_timepreference=1.0333333333.
 
 The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric 
-tonnes (this does not change the units of the returned value, which is always normalized by the `pulse_size` used).
+tonnes of CO2 (this does not change the units of the returned value, which is always normalized by the `pulse_size` used).
 
 By default, `n = nothing`, and a single value for the "best guess" social cost of CO2 is returned. If a positive 
 value for keyword `n` is specified, then a Monte Carlo simulation with sample size `n` will run, sampling from 

--- a/src/compute_scc.jl
+++ b/src/compute_scc.jl
@@ -129,11 +129,12 @@ function compute_scc(
     
     mm = get_marginal_model(m, year=year, pulse_size=pulse_size)   # Returns a marginal model that has already been run
 
-    if n<1
-        error("Invalid `n` value, must be >=1.")    
-    elseif n===nothing
+   
+    if n===nothing
         # Run the "best guess" social cost calculation (deterministic)
         scc = _compute_scc_from_mm(mm, year=year, prtp=prtp, eta=eta, equity_weighting=equity_weighting)
+    elseif n<1
+        error("Invalid `n` value, must be >=1.") 
     else
         # Run a Monte Carlo simulation of size `n`
         simdef = getsim()

--- a/test/test_standard_api.jl
+++ b/test/test_standard_api.jl
@@ -45,4 +45,9 @@ sccs3 = MimiPAGE2009.compute_scc(year=2020, n=10, seed=351)
 @test MimiPAGE2009.compute_scc(year=2020, eta=0., prtp = 0.03, equity_weighting = true) ==
         MimiPAGE2009.compute_scc(year=2020, eta=0., prtp = 0.03, equity_weighting = false)
 
+# Test Monte Carlo w/ and w/o equity weighting, with the same seed
+scc10a = MimiPAGE2009.compute_scc(year=2020, eta=1.5, prtp = 0.01, equity_weighting = true, n = 10, seed=350)
+scc10b = MimiPAGE2009.compute_scc(year=2020, eta=1.5, prtp = 0.01, equity_weighting = false, n = 10, seed=350)
+@test all(scc10a .> scc10b)
+
 end

--- a/test/test_standard_api.jl
+++ b/test/test_standard_api.jl
@@ -34,4 +34,15 @@ sccs2 = MimiPAGE2009.compute_scc(year=2020, n=10, seed=350)
 sccs3 = MimiPAGE2009.compute_scc(year=2020, n=10, seed=351)
 @test sccs3 != sccs1
 
+
+#Test equity weighting options
+
+# Test that regional equity weighting inreases the SCC
+@test MimiPAGE2009.compute_scc(year=2020, eta=1.5, prtp = 0.01, equity_weighting = true) >
+        MimiPAGE2009.compute_scc(year=2020, eta=1.5, prtp = 0.01, equity_weighting = false)
+
+# Test that when eta==0, equity_weighting does not change the SCC value
+@test MimiPAGE2009.compute_scc(year=2020, eta=0., prtp = 0.03, equity_weighting = true) ==
+        MimiPAGE2009.compute_scc(year=2020, eta=0., prtp = 0.03, equity_weighting = false)
+
 end


### PR DESCRIPTION
This PR adds a keyword argument `equity_weighting::Bool = true` to the `compute_scc` function. 

If `equity_weighting == true`, then to compute the SCC we continue using the `:td_totaldiscountedimpacts` variable from the `EquityWeighting` component.  But if `equity_weighting == false && eta!=0` (that is, someone wants to perform Ramsey time discounting without regional equity weighting) then we perform the necessary discounting procedure after the model has been run.