### PR TITLE
Resolve Treatment of Unshared Parameters in MCS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ julia = "1.4"
 Distributions = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 CSVFiles = "0.16, 1"
 DataFrames = "0.19.1, 0.20, 0.21, 0.22, 1.0"
-Mimi = "0.10, 1.0"
+Mimi = "1.3"
 
 [targets]
 test = ["Test"]

--- a/src/compute_scc.jl
+++ b/src/compute_scc.jl
@@ -134,8 +134,8 @@ function compute_scc(
         # Run a Monte Carlo simulation
 
         simdef = getsim()   # get the default simulation, need to remove :emuc_utilityconvexity and :ptp_timepreference RVs if user specified values for these
-        eta !== nothing ? _remove_RV!(simdef, :emuc_utilityconvexity) : nothing
-        prtp !== nothing ? _remove_RV!(simdef, :ptp_timepreference) : nothing
+        eta !== nothing ? _remove_RV!(simdef, "EquityWeighting.emuc_utilityconvexity") : nothing
+        prtp !== nothing ? _remove_RV!(simdef, "EquityWeighting.ptp_timepreference") : nothing
        
         seed !== nothing ? Random.seed!(seed) : nothing
         Mimi.set_payload!(simdef, (Vector{Float64}(undef, n), year))  # pass the year and a vector for storing SCC values to the `run` function

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -11,14 +11,20 @@ function getsim()
 
                 # each component should have the same value for its save_savingsrate,
                 # so we use an RV here because in the model this is not an explicitly
-                # shared parameter, then assign below in component section
+                # shared parameter, then assign to components
                 rv(RV_save_savingsrate) = TriangularDist(10, 20, 15)
+                GDP.save_savingsrate = RV_save_savingsrate
+                MarketDamages.save_savingsrate = RV_save_savingsrate
+                NonMarketDamages.save_savingsrate = RV_save_savingsrate
+                SLRDamages.save_savingsrate = RV_save_savingsrate
 
                 # each component should have the same value for its tcal_CalibrationTemp
                 # so we use an RV here because in the model this is not an explicitly
-                # shared parameter, then assign below in component section
+                # shared parameter, then assign to components
                 rv(RV_tcal_CalibrationTemp) = TriangularDist(2.5, 3.5, 3.)
-                
+                MarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
+                NonMarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
+
                 # CO2cycle
                 co2cycle.air_CO2fractioninatm = TriangularDist(57, 67, 62)
                 co2cycle.res_CO2atmlifetime = TriangularDist(50, 100, 70)
@@ -43,27 +49,21 @@ function getsim()
                 SeaLevelRise.sltau_SLresponsetime = TriangularDist(500, 1500, 1000)
                 
                 # GDP
-                GDP.save_savingsrate = RV_save_savingsrate
                 GDP.isat0_initialimpactfxnsaturation = TriangularDist(20, 50, 30) 
                 
                 # MarketDamages
-                MarketDamages.save_savingsrate = RV_save_savingsrate
-                MarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
                 MarketDamages.iben_MarketInitialBenefit = TriangularDist(0, .3, .1)
                 MarketDamages.W_MarketImpactsatCalibrationTemp = TriangularDist(.2, .8, .5)
                 MarketDamages.pow_MarketImpactExponent = TriangularDist(1.5, 3, 2)
                 MarketDamages.ipow_MarketIncomeFxnExponent = TriangularDist(-.3, 0, -.1)
 
                 # NonMarketDamages
-                NonMarketDamages.save_savingsrate = RV_save_savingsrate
-                NonMarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
                 NonMarketDamages.iben_NonMarketInitialBenefit = TriangularDist(0, .2, .05)
                 NonMarketDamages.w_NonImpactsatCalibrationTemp = TriangularDist(.1, 1, .5)
                 NonMarketDamages.pow_NonMarketExponent = TriangularDist(1.5, 3, 2)
                 NonMarketDamages.ipow_NonMarketIncomeFxnExponent = TriangularDist(-.2, .2, 0)
                 
                 # SLRDamages
-                SLRDamages.save_savingsrate = RV_save_savingsrate
                 SLRDamages.scal_calibrationSLR = TriangularDist(0.45, 0.55, .5)
                 #SLRDamages.iben_SLRInitialBenefit = TriangularDist(0, 0, 0) # only usable if lb <> ub
                 SLRDamages.W_SatCalibrationSLR = TriangularDist(.5, 1.5, 1)
@@ -127,14 +127,6 @@ function getsim()
                 cmaxf_maxcostfactor["Africa"] = TriangularDist(1,1.5,1.2)
                 cmaxf_maxcostfactor["LatAmerica"] = TriangularDist(0.4,1.0,0.7)
                 
-                q0propmult_cutbacksatnegativecostinfinalyear = TriangularDist(0.3,1.2,0.7)
-                qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear = TriangularDist(1,1.5,1.3)
-                c0mult_mostnegativecostinfinalyear = TriangularDist(0.5,1.2,0.8)
-                curve_below_curvatureofMACcurvebelowzerocost = TriangularDist(0.25,0.8,0.45)
-                curve_above_curvatureofMACcurveabovezerocost = TriangularDist(0.1,0.7,0.4)
-                cross_experiencecrossoverratio = TriangularDist(0.1,0.3,0.2)
-                learn_learningrate = TriangularDist(0.05,0.35,0.2)
-                
                 cf_costregional["USA"] = TriangularDist(0.6, 1, 0.8)
                 cf_costregional["OECD"] = TriangularDist(0.4, 1.2, 0.8)
                 cf_costregional["USSR"] = TriangularDist(0.2, 0.6, 0.4)
@@ -143,12 +135,20 @@ function getsim()
                 cf_costregional["Africa"] = TriangularDist(0.4, 0.8, 0.6)
                 cf_costregional["LatAmerica"] = TriangularDist(0.4, 0.8, 0.6)
 
+                # Other
+                q0propmult_cutbacksatnegativecostinfinalyear = TriangularDist(0.3,1.2,0.7)
+                qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear = TriangularDist(1,1.5,1.3)
+                c0mult_mostnegativecostinfinalyear = TriangularDist(0.5,1.2,0.8)
+                curve_below_curvatureofMACcurvebelowzerocost = TriangularDist(0.25,0.8,0.45)
+                curve_above_curvatureofMACcurveabovezerocost = TriangularDist(0.1,0.7,0.4)
+                cross_experiencecrossoverratio = TriangularDist(0.1,0.3,0.2)
+                learn_learningrate = TriangularDist(0.05,0.35,0.2)
+
                 # NOTE: the below can probably be resolved into unique, unshared parameters with the same name
                 # in the new Mimi paradigm of shared and unshared parameters, but for now this will 
                 # continue to work!
 
                 # AbatementCosts
-
                 AbatementCostParametersCO2_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,75,0)
                 AbatementCostParametersCH4_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-25,100,0)
                 AbatementCostParametersN2O_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,50,0)
@@ -180,7 +180,6 @@ function getsim()
                 AbatementCostParametersLin_ies_InitialExperienceStockofCutbacks = TriangularDist(1500,2500,2000)
 
                 # AdaptationCosts
-
                 AdaptiveCostsSeaLevel_cp_costplateau_eu = TriangularDist(0.01, 0.04, 0.02)
                 AdaptiveCostsSeaLevel_ci_costimpact_eu = TriangularDist(0.0005, 0.002, 0.001)
                 AdaptiveCostsEconomic_cp_costplateau_eu = TriangularDist(0.005, 0.02, 0.01)

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -13,8 +13,21 @@ function getsim()
                 #set here as opposed to below within the blocks of RVs separated by component
                 #so that they are not set more than once.
 
-                save_savingsrate = TriangularDist(10, 20, 15) # components: MarketDamages, NonMarketDamages, GDP, SLRDamages
-                tcal_CalibrationTemp = TriangularDist(2.5, 3.5, 3.) # components: MarketDamages, NonMarketDamages
+                # each component should have the same value for its save_savingsrate,
+                # so we use an RV here because in the model this is not an explicitly
+                # shared parameter
+                rv(RV_save_savingsrate) = TriangularDist(10, 20, 15)
+                MarketDamages.save_savingsrate = RV_save_savingsrate
+                NonMarketDamages.save_savingsrate = RV_save_savingsrate
+                GDP.save_savingsrate = RV_save_savingsrate
+                SLRDamages.save_savingsrate = RV_save_savingsrate
+
+                # each component should have the same value for its tcal_CalibrationTemp
+                # so we use an RV here because in the model this is not an explicitly
+                # shared parameter
+                rv(RV_tcal_CalibrationTemp) = TriangularDist(2.5, 3.5, 3.)
+                MarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
+                NonMarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
 
                 wincf_weightsfactor["USA"] = TriangularDist(.6, 1, .8) # components: MarketDamages, NonMarketDamages, SLRDamages, Discountinuity
                 wincf_weightsfactor["OECD"] = TriangularDist(.4, 1.2, .8)

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -25,7 +25,7 @@ function getsim()
                 MarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
                 NonMarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
 
-                # shared external variable in components: MarketDamages, NonMarketDamages, 
+                # shared parameter linked to components: MarketDamages, NonMarketDamages, 
                 # SLRDamages, Discountinuity
                 wincf_weightsfactor["USA"] = TriangularDist(.6, 1, .8) 
                 wincf_weightsfactor["OECD"] = TriangularDist(.4, 1.2, .8)
@@ -35,7 +35,7 @@ function getsim()
                 wincf_weightsfactor["Africa"] = TriangularDist(.4, .8, .6)
                 wincf_weightsfactor["LatAmerica"] = TriangularDist(.4, .8, .6)
 
-                # shared external variable in components: AdaptationCosts, AbatementCosts
+                # shared parameter linked to components: AdaptationCosts, AbatementCosts
                 automult_autonomouschange = TriangularDist(0.5, 0.8, 0.65)  
                 
                 #The following RVs are divided into blocks by component

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -6,40 +6,19 @@ function getsim()
         mcs = @defsim begin
                 
                 ############################################################################
-                # Define random variables (RVs) 
+                # Define random variables (RVs) - for UNSHARED parameters
                 ############################################################################
 
                 # each component should have the same value for its save_savingsrate,
                 # so we use an RV here because in the model this is not an explicitly
-                # shared parameter
+                # shared parameter, then assign below in component section
                 rv(RV_save_savingsrate) = TriangularDist(10, 20, 15)
-                MarketDamages.save_savingsrate = RV_save_savingsrate
-                NonMarketDamages.save_savingsrate = RV_save_savingsrate
-                GDP.save_savingsrate = RV_save_savingsrate
-                SLRDamages.save_savingsrate = RV_save_savingsrate
 
                 # each component should have the same value for its tcal_CalibrationTemp
                 # so we use an RV here because in the model this is not an explicitly
-                # shared parameter
+                # shared parameter, then assign below in component section
                 rv(RV_tcal_CalibrationTemp) = TriangularDist(2.5, 3.5, 3.)
-                MarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
-                NonMarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
-
-                # shared parameter linked to components: MarketDamages, NonMarketDamages, 
-                # SLRDamages, Discountinuity
-                wincf_weightsfactor["USA"] = TriangularDist(.6, 1, .8) 
-                wincf_weightsfactor["OECD"] = TriangularDist(.4, 1.2, .8)
-                wincf_weightsfactor["USSR"] = TriangularDist(.2, .6, .4)
-                wincf_weightsfactor["China"] = TriangularDist(.4, 1.2, .8)
-                wincf_weightsfactor["SEAsia"] = TriangularDist(.4, 1.2, .8)
-                wincf_weightsfactor["Africa"] = TriangularDist(.4, .8, .6)
-                wincf_weightsfactor["LatAmerica"] = TriangularDist(.4, .8, .6)
-
-                # shared parameter linked to components: AdaptationCosts, AbatementCosts
-                automult_autonomouschange = TriangularDist(0.5, 0.8, 0.65)  
                 
-                #The following RVs are divided into blocks by component
-
                 # CO2cycle
                 co2cycle.air_CO2fractioninatm = TriangularDist(57, 67, 62)
                 co2cycle.res_CO2atmlifetime = TriangularDist(50, 100, 70)
@@ -64,21 +43,27 @@ function getsim()
                 SeaLevelRise.sltau_SLresponsetime = TriangularDist(500, 1500, 1000)
                 
                 # GDP
+                GDP.save_savingsrate = RV_save_savingsrate
                 GDP.isat0_initialimpactfxnsaturation = TriangularDist(20, 50, 30) 
                 
                 # MarketDamages
+                MarketDamages.save_savingsrate = RV_save_savingsrate
+                MarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
                 MarketDamages.iben_MarketInitialBenefit = TriangularDist(0, .3, .1)
                 MarketDamages.W_MarketImpactsatCalibrationTemp = TriangularDist(.2, .8, .5)
                 MarketDamages.pow_MarketImpactExponent = TriangularDist(1.5, 3, 2)
                 MarketDamages.ipow_MarketIncomeFxnExponent = TriangularDist(-.3, 0, -.1)
 
                 # NonMarketDamages
+                NonMarketDamages.save_savingsrate = RV_save_savingsrate
+                NonMarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
                 NonMarketDamages.iben_NonMarketInitialBenefit = TriangularDist(0, .2, .05)
                 NonMarketDamages.w_NonImpactsatCalibrationTemp = TriangularDist(.1, 1, .5)
                 NonMarketDamages.pow_NonMarketExponent = TriangularDist(1.5, 3, 2)
                 NonMarketDamages.ipow_NonMarketIncomeFxnExponent = TriangularDist(-.2, .2, 0)
                 
                 # SLRDamages
+                SLRDamages.save_savingsrate = RV_save_savingsrate
                 SLRDamages.scal_calibrationSLR = TriangularDist(0.45, 0.55, .5)
                 #SLRDamages.iben_SLRInitialBenefit = TriangularDist(0, 0, 0) # only usable if lb <> ub
                 SLRDamages.W_SatCalibrationSLR = TriangularDist(.5, 1.5, 1)
@@ -98,37 +83,23 @@ function getsim()
                 EquityWeighting.ptp_timepreference = TriangularDist(0.1,2,1)
                 EquityWeighting.emuc_utilityconvexity = TriangularDist(0.5,2,1)
                 
-                # AbatementCosts
-                AbatementCostParametersCO2_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,75,0)
-                AbatementCostParametersCH4_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-25,100,0)
-                AbatementCostParametersN2O_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,50,0)
-                AbatementCostParametersLin_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,50,0)
-                
-                AbatementCostParametersCO2_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,40,20)
-                AbatementCostParametersCH4_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
-                AbatementCostParametersN2O_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
-                AbatementCostParametersLin_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
-                
-                AbatementCostParametersCO2_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-400,-100,-200)
-                AbatementCostParametersCH4_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-8000,-1000,-4000)
-                AbatementCostParametersN2O_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-15000,0,-7000)
-                AbatementCostParametersLin_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-400,-100,-200)
-                
-                AbatementCostParametersCO2_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(60,80,70)
-                AbatementCostParametersCH4_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(35,70,50)
-                AbatementCostParametersN2O_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(35,70,50)
-                AbatementCostParametersLin_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(60,80,70)
-                
-                AbatementCostParametersCO2_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(100,700,400)
-                AbatementCostParametersCH4_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(3000,10000,6000)
-                AbatementCostParametersN2O_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(2000,60000,20000)
-                AbatementCostParametersLin_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(100,600,300)
-                
-                AbatementCostParametersCO2_ies_InitialExperienceStockofCutbacks = TriangularDist(100000,200000,150000)
-                AbatementCostParametersCH4_ies_InitialExperienceStockofCutbacks = TriangularDist(1500,2500,2000)
-                AbatementCostParametersN2O_ies_InitialExperienceStockofCutbacks = TriangularDist(30,80,50)
-                AbatementCostParametersLin_ies_InitialExperienceStockofCutbacks = TriangularDist(1500,2500,2000)
-                
+                ############################################################################
+                # Define random variables (RVs) - for SHARED parameters
+                ############################################################################
+
+                # shared parameter linked to components: MarketDamages, NonMarketDamages, 
+                # SLRDamages, Discountinuity
+                wincf_weightsfactor["USA"] = TriangularDist(.6, 1, .8) 
+                wincf_weightsfactor["OECD"] = TriangularDist(.4, 1.2, .8)
+                wincf_weightsfactor["USSR"] = TriangularDist(.2, .6, .4)
+                wincf_weightsfactor["China"] = TriangularDist(.4, 1.2, .8)
+                wincf_weightsfactor["SEAsia"] = TriangularDist(.4, 1.2, .8)
+                wincf_weightsfactor["Africa"] = TriangularDist(.4, .8, .6)
+                wincf_weightsfactor["LatAmerica"] = TriangularDist(.4, .8, .6)
+
+                # shared parameter linked to components: AdaptationCosts, AbatementCosts
+                automult_autonomouschange = TriangularDist(0.5, 0.8, 0.65)  
+
                 #the following variables need to be set, but set the same in all 4 abatement cost components
                 #note that for these regional variables, the first region is the focus region (EU), which is set in the preceding code, and so is always one for these variables
                 
@@ -164,14 +135,6 @@ function getsim()
                 cross_experiencecrossoverratio = TriangularDist(0.1,0.3,0.2)
                 learn_learningrate = TriangularDist(0.05,0.35,0.2)
                 
-                # AdaptationCosts
-                AdaptiveCostsSeaLevel_cp_costplateau_eu = TriangularDist(0.01, 0.04, 0.02)
-                AdaptiveCostsSeaLevel_ci_costimpact_eu = TriangularDist(0.0005, 0.002, 0.001)
-                AdaptiveCostsEconomic_cp_costplateau_eu = TriangularDist(0.005, 0.02, 0.01)
-                AdaptiveCostsEconomic_ci_costimpact_eu = TriangularDist(0.001, 0.008, 0.003)
-                AdaptiveCostsNonEconomic_cp_costplateau_eu = TriangularDist(0.01, 0.04, 0.02)
-                AdaptiveCostsNonEconomic_ci_costimpact_eu = TriangularDist(0.002, 0.01, 0.005)
-                
                 cf_costregional["USA"] = TriangularDist(0.6, 1, 0.8)
                 cf_costregional["OECD"] = TriangularDist(0.4, 1.2, 0.8)
                 cf_costregional["USSR"] = TriangularDist(0.2, 0.6, 0.4)
@@ -179,6 +142,51 @@ function getsim()
                 cf_costregional["SEAsia"] = TriangularDist(0.4, 1.2, 0.8)
                 cf_costregional["Africa"] = TriangularDist(0.4, 0.8, 0.6)
                 cf_costregional["LatAmerica"] = TriangularDist(0.4, 0.8, 0.6)
+
+                # NOTE: the below can probably be resolved into unique, unshared parameters with the same name
+                # in the new Mimi paradigm of shared and unshared parameters, but for now this will 
+                # continue to work!
+
+                # AbatementCosts
+
+                AbatementCostParametersCO2_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,75,0)
+                AbatementCostParametersCH4_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-25,100,0)
+                AbatementCostParametersN2O_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,50,0)
+                AbatementCostParametersLin_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,50,0)
+                
+                AbatementCostParametersCO2_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,40,20)
+                AbatementCostParametersCH4_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
+                AbatementCostParametersN2O_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
+                AbatementCostParametersLin_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
+                
+                AbatementCostParametersCO2_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-400,-100,-200)
+                AbatementCostParametersCH4_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-8000,-1000,-4000)
+                AbatementCostParametersN2O_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-15000,0,-7000)
+                AbatementCostParametersLin_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-400,-100,-200)
+                
+                AbatementCostParametersCO2_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(60,80,70)
+                AbatementCostParametersCH4_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(35,70,50)
+                AbatementCostParametersN2O_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(35,70,50)
+                AbatementCostParametersLin_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(60,80,70)
+                
+                AbatementCostParametersCO2_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(100,700,400)
+                AbatementCostParametersCH4_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(3000,10000,6000)
+                AbatementCostParametersN2O_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(2000,60000,20000)
+                AbatementCostParametersLin_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(100,600,300)
+                
+                AbatementCostParametersCO2_ies_InitialExperienceStockofCutbacks = TriangularDist(100000,200000,150000)
+                AbatementCostParametersCH4_ies_InitialExperienceStockofCutbacks = TriangularDist(1500,2500,2000)
+                AbatementCostParametersN2O_ies_InitialExperienceStockofCutbacks = TriangularDist(30,80,50)
+                AbatementCostParametersLin_ies_InitialExperienceStockofCutbacks = TriangularDist(1500,2500,2000)
+
+                # AdaptationCosts
+
+                AdaptiveCostsSeaLevel_cp_costplateau_eu = TriangularDist(0.01, 0.04, 0.02)
+                AdaptiveCostsSeaLevel_ci_costimpact_eu = TriangularDist(0.0005, 0.002, 0.001)
+                AdaptiveCostsEconomic_cp_costplateau_eu = TriangularDist(0.005, 0.02, 0.01)
+                AdaptiveCostsEconomic_ci_costimpact_eu = TriangularDist(0.001, 0.008, 0.003)
+                AdaptiveCostsNonEconomic_cp_costplateau_eu = TriangularDist(0.01, 0.04, 0.02)
+                AdaptiveCostsNonEconomic_ci_costimpact_eu = TriangularDist(0.002, 0.01, 0.005)
 
                 ############################################################################
                 # Indicate which parameters to save for each model run

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -8,7 +8,6 @@ function getsim()
                 ############################################################################
                 # Define random variables (RVs) 
                 ############################################################################
-                
 
                 # each component should have the same value for its save_savingsrate,
                 # so we use an RV here because in the model this is not an explicitly

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -9,9 +9,6 @@ function getsim()
                 # Define random variables (RVs) 
                 ############################################################################
                 
-                #The folllowing RVs are in more than one component.  For clarity they are 
-                #set here as opposed to below within the blocks of RVs separated by component
-                #so that they are not set more than once.
 
                 # each component should have the same value for its save_savingsrate,
                 # so we use an RV here because in the model this is not an explicitly
@@ -29,7 +26,9 @@ function getsim()
                 MarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
                 NonMarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
 
-                wincf_weightsfactor["USA"] = TriangularDist(.6, 1, .8) # components: MarketDamages, NonMarketDamages, SLRDamages, Discountinuity
+                # shared external variable in components: MarketDamages, NonMarketDamages, 
+                # SLRDamages, Discountinuity
+                wincf_weightsfactor["USA"] = TriangularDist(.6, 1, .8) 
                 wincf_weightsfactor["OECD"] = TriangularDist(.4, 1.2, .8)
                 wincf_weightsfactor["USSR"] = TriangularDist(.2, .6, .4)
                 wincf_weightsfactor["China"] = TriangularDist(.4, 1.2, .8)
@@ -37,67 +36,68 @@ function getsim()
                 wincf_weightsfactor["Africa"] = TriangularDist(.4, .8, .6)
                 wincf_weightsfactor["LatAmerica"] = TriangularDist(.4, .8, .6)
 
-                automult_autonomouschange = TriangularDist(0.5, 0.8, 0.65)  #components: AdaptationCosts, AbatementCosts
+                # shared external variable in components: AdaptationCosts, AbatementCosts
+                automult_autonomouschange = TriangularDist(0.5, 0.8, 0.65)  
                 
                 #The following RVs are divided into blocks by component
 
                 # CO2cycle
-                air_CO2fractioninatm = TriangularDist(57, 67, 62)
-                res_CO2atmlifetime = TriangularDist(50, 100, 70)
-                ccf_CO2feedback = TriangularDist(4, 15, 10)
-                ccfmax_maxCO2feedback = TriangularDist(30, 80, 50)
-                stay_fractionCO2emissionsinatm = TriangularDist(0.25,0.35,0.3)
+                co2cycle.air_CO2fractioninatm = TriangularDist(57, 67, 62)
+                co2cycle.res_CO2atmlifetime = TriangularDist(50, 100, 70)
+                co2cycle.ccf_CO2feedback = TriangularDist(4, 15, 10)
+                co2cycle.ccfmax_maxCO2feedback = TriangularDist(30, 80, 50)
+                co2cycle.stay_fractionCO2emissionsinatm = TriangularDist(0.25,0.35,0.3)
                 
                 # SulphateForcing
-                d_sulphateforcingbase = TriangularDist(-0.8, -0.2, -0.4)
-                ind_slopeSEforcing_indirect = TriangularDist(-0.8, 0, -0.4)
+                SulphateForcing.d_sulphateforcingbase = TriangularDist(-0.8, -0.2, -0.4)
+                SulphateForcing.ind_slopeSEforcing_indirect = TriangularDist(-0.8, 0, -0.4)
                 
                 # ClimateTemperature
-                rlo_ratiolandocean = TriangularDist(1.2, 1.6, 1.4)
-                pole_polardifference = TriangularDist(1, 2, 1.5)
-                frt_warminghalflife = TriangularDist(10, 65, 30)
-                tcr_transientresponse = TriangularDist(1, 2.8, 1.3)
+                ClimateTemperature.rlo_ratiolandocean = TriangularDist(1.2, 1.6, 1.4)
+                ClimateTemperature.pole_polardifference = TriangularDist(1, 2, 1.5)
+                ClimateTemperature.frt_warminghalflife = TriangularDist(10, 65, 30)
+                ClimateTemperature.tcr_transientresponse = TriangularDist(1, 2.8, 1.3)
                 
                 # SeaLevelRise
-                s0_initialSL = TriangularDist(0.1, 0.2, 0.15)
-                sltemp_SLtemprise = TriangularDist(0.7, 3., 1.5)
-                sla_SLbaselinerise = TriangularDist(0.5, 1.5, 1.)
-                sltau_SLresponsetime = TriangularDist(500, 1500, 1000)
+                SeaLevelRise.s0_initialSL = TriangularDist(0.1, 0.2, 0.15)
+                SeaLevelRise.sltemp_SLtemprise = TriangularDist(0.7, 3., 1.5)
+                SeaLevelRise.sla_SLbaselinerise = TriangularDist(0.5, 1.5, 1.)
+                SeaLevelRise.sltau_SLresponsetime = TriangularDist(500, 1500, 1000)
                 
                 # GDP
-                isat0_initialimpactfxnsaturation = TriangularDist(20, 50, 30) 
+                GDP.isat0_initialimpactfxnsaturation = TriangularDist(20, 50, 30) 
                 
                 # MarketDamages
-                iben_MarketInitialBenefit = TriangularDist(0, .3, .1)
-                W_MarketImpactsatCalibrationTemp = TriangularDist(.2, .8, .5)
-                pow_MarketImpactExponent = TriangularDist(1.5, 3, 2)
-                ipow_MarketIncomeFxnExponent = TriangularDist(-.3, 0, -.1)
+                MarketDamages.iben_MarketInitialBenefit = TriangularDist(0, .3, .1)
+                MarketDamages.W_MarketImpactsatCalibrationTemp = TriangularDist(.2, .8, .5)
+                MarketDamages.pow_MarketImpactExponent = TriangularDist(1.5, 3, 2)
+                MarketDamages.ipow_MarketIncomeFxnExponent = TriangularDist(-.3, 0, -.1)
 
                 # NonMarketDamages
-                iben_NonMarketInitialBenefit = TriangularDist(0, .2, .05)
-                w_NonImpactsatCalibrationTemp = TriangularDist(.1, 1, .5)
-                pow_NonMarketExponent = TriangularDist(1.5, 3, 2)
-                ipow_NonMarketIncomeFxnExponent = TriangularDist(-.2, .2, 0)
+                NonMarketDamages.iben_NonMarketInitialBenefit = TriangularDist(0, .2, .05)
+                NonMarketDamages.w_NonImpactsatCalibrationTemp = TriangularDist(.1, 1, .5)
+                NonMarketDamages.pow_NonMarketExponent = TriangularDist(1.5, 3, 2)
+                NonMarketDamages.ipow_NonMarketIncomeFxnExponent = TriangularDist(-.2, .2, 0)
                 
                 # SLRDamages
-                scal_calibrationSLR = TriangularDist(0.45, 0.55, .5)
-                #iben_SLRInitialBenefit = TriangularDist(0, 0, 0) # only usable if lb <> ub
-                W_SatCalibrationSLR = TriangularDist(.5, 1.5, 1)
-                pow_SLRImpactFxnExponent = TriangularDist(.5, 1, .7)
-                ipow_SLRIncomeFxnExponent = TriangularDist(-.4, -.2, -.3)
+                SLRDamages.scal_calibrationSLR = TriangularDist(0.45, 0.55, .5)
+                #SLRDamages.iben_SLRInitialBenefit = TriangularDist(0, 0, 0) # only usable if lb <> ub
+                SLRDamages.W_SatCalibrationSLR = TriangularDist(.5, 1.5, 1)
+                SLRDamages.pow_SLRImpactFxnExponent = TriangularDist(.5, 1, .7)
+                SLRDamages.ipow_SLRIncomeFxnExponent = TriangularDist(-.4, -.2, -.3)
                 
-                # Discountinuity
-                rand_discontinuity = Uniform(0, 1)
-                tdis_tolerabilitydisc = TriangularDist(2, 4, 3)
-                pdis_probability = TriangularDist(10, 30, 20)
-                wdis_gdplostdisc = TriangularDist(5, 25, 15)
-                ipow_incomeexponent = TriangularDist(-.3, 0, -.1)
-                distau_discontinuityexponent = TriangularDist(20, 200, 50)
+                # Discontinuity
+                Discontinuity.rand_discontinuity = Uniform(0, 1)
+                Discontinuity.tdis_tolerabilitydisc = TriangularDist(2, 4, 3)
+                Discontinuity.pdis_probability = TriangularDist(10, 30, 20)
+                Discontinuity.wdis_gdplostdisc = TriangularDist(5, 25, 15)
+                Discontinuity.ipow_incomeexponent = TriangularDist(-.3, 0, -.1)
+                Discontinuity.distau_discontinuityexponent = TriangularDist(20, 200, 50)
                 
                 # EquityWeighting
-                civvalue_civilizationvalue = TriangularDist(1e10, 1e11, 5e10)
-                ptp_timepreference = TriangularDist(0.1,2,1)
-                emuc_utilityconvexity = TriangularDist(0.5,2,1)
+                EquityWeighting.civvalue_civilizationvalue = TriangularDist(1e10, 1e11, 5e10)
+                EquityWeighting.ptp_timepreference = TriangularDist(0.1,2,1)
+                EquityWeighting.emuc_utilityconvexity = TriangularDist(0.5,2,1)
                 
                 # AbatementCosts
                 AbatementCostParametersCO2_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,75,0)


### PR DESCRIPTION
@jrising we can discuss this so it's clear to you, with regards to the Mimi PR [here](https://github.com/mimiframework/Mimi.jl/pull/829) so that warnings will not be thrown.  This should not be merged until that Mimi PR is merged, at which point we need to update compat for Mimi to this latest feature release.

---

We will be slightly revamping how parameters are internally stored, and the API for setting and updating them, in order to respond to user comments and simplify the experience.  This **should not be breaking**, so old code should work, and we will explain things clearly in documentation, but to summarize:

In our new paradigm, model parameters can either by unshared and unnamed, specific to one component with a generated name under the hood, or shared and named, specific to several components all parameters in components and named explicitly.  Previously most parameters ended up as shared, named parameters since this is automatically done by `set_param!`.  Now this is not done unless it is explicitly written by the user, and most parameters will be unshared, including those set by default. This should improve Mimi by:

- reducing the confusion of the API, users will only need to work with two calls: `update_param!`, `create_shared_param!`, and `connect_param!`
- reducing confusion around when values get automatically connected to all parameters with a given name

**This suggests two changes in MimiPAGE2009, the first will cause an error in the next Mimi release because it's a revealed bug, the second just warnings.**

1. Previously when a parameter was set using a `default = xx` statement, that parameter became a shared parameter in the model's parameter list, and any parameter in the model with that parameter name was connected to the same external parameter and also received that default value since under the hood we called `set_param!(m, paramname, xx)`.  This didn't cause bugs in practice because parameters (like `save_savingsrate`) had defaults that were the same in each component, but really this should be considered a bug ... we should not assume that component's with parameters of the same name have the same value unless explicitly stated by the model creator. 

`save_savingsrate` and `tcal_CalibrationTemp` were previously set using defaults and assumed to be shared across components, which as stated we consider a bug. They were then used in the Monte Carlo Simulation code as if there was one shared model parameter that could be changed ... but now each of the components with these parameters has their own unshared model parameter so we cannot use them in this way.  We adopt the mcs code from 

```
tcal_CalibrationTemp = TriangularDist(2.5, 3.5, 3.) # errors now because tcal_CalibrationTemp is in multiple components as has multiple unshared parameters in the model space, so we cannot make assumptions under the hood
```
to
```
rv(RV_tcal_CalibrationTemp) = TriangularDist(2.5, 3.5, 3.)
MarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
NonMarketDamages.tcal_CalibrationTemp = RV_tcal_CalibrationTemp
```
so the behavior is the same.

2. Several parameters were referred to as by name, but they are now unshared model parameters because they are set by default.  We can resolve this under the hood as long as they are only found in one component, but we throw a warning and suggest using syntax specific to the component to be clear.  We adopt the mcs code from

```
air_CO2fractioninatm = TriangularDist(57, 67, 62) # throws warning about resolving and that it was found in (and only in) co2cycle
```
to
```
co2cycle.air_CO2fractioninatm = TriangularDist(57, 67, 62)
```