### PR TITLE
Add documentation about pulse size

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ scc = MimiPAGE2009.compute_scc(m, year=2020)    # compute the scc from the modif
 The first argument to the `compute_scc` function is a MimiPAGE2009 model, and it is an optional argument. If no model is provided, the default MimiPAGE2009 model will be used. 
 There are also other keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
 ```
-compute_scc(m = get_model(),  # if no model provided, will use the default MimiPAGE2009 model
+compute_scc(
+    m = get_model(),  # if no model provided, will use the default MimiPAGE2009 model
     year = nothing,  # user must specify an emission year for the SCC calculation
     eta = nothing,  # eta parameter for ramsey discounting representing the elasticity of marginal utility. If nothing is provided, the value of parameter :emuc_utiliyconvexity in the MimiPAGE2009 model is unchanged, which has a default value of 1.1666666667.
     prtp = nothing  # pure rate of time preference parameter used for discounting. If nothing is provided, the value of parameter :ptp_timepreference in the MimiPAGE2009 model is unchanged, which has a default value of 1.0333333333%.
@@ -87,6 +88,12 @@ result.mm   # returns the Mimi MarginalModel
 
 marginal_temp = result.mm[:ClimateTemperature, :rt_realizedtemperature]  # marginal results from the marginal model can be accessed like this
 ```
+
+### Pulse Size Details
+
+By default, MimiPAGE2009 will calculate the SCC using a marginal emissions pulse of 100_000 metric tonnes of CO2 spread over the years in the period following `year`.  Regardless of this pulse size, the SC will be returned in units of dollars per ton.  This choice of pulse size and duration is a decision made based on experiments with stability of results and moving from continuous to discretized equations, and can be found described further in the literature around PAGE.
+
+If you wish to alter this pulse size, it is an optional keyword argument to the  `compute_scc` function where `pulse_size` controls the size of the marginal emission pulse. For a deeper dive into the machinery of this function, see the forum conversation [here](https://forum.mimiframework.org/t/mimifund-emissions-pulse/153/9) and the docstrings in `compute_scc.jl`.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ compute_scc(
     m = get_model(),  # if no model provided, will use the default MimiPAGE2009 model
     year = nothing,  # user must specify an emission year for the SCC calculation
     eta = nothing,  # eta parameter for ramsey discounting representing the elasticity of marginal utility. If nothing is provided, the value of parameter :emuc_utiliyconvexity in the MimiPAGE2009 model is unchanged, which has a default value of 1.1666666667.
-    prtp = nothing  # pure rate of time preference parameter used for discounting. If nothing is provided, the value of parameter :ptp_timepreference in the MimiPAGE2009 model is unchanged, which has a default value of 1.0333333333%.
+    prtp = nothing,  # pure rate of time preference parameter used for discounting. If nothing is provided, the value of parameter :ptp_timepreference in the MimiPAGE2009 model is unchanged, which has a default value of 1.0333333333%.
+    equity_weighting  = true,
+    pulse_size = 100_000 # the pulse size in metric megatonnes of CO2 (Mtonne CO2) (see below for more details)
 )
 ```
 There is an additional function for computing the SCC that also returns the MarginalModel that was used to compute it. It returns these two values as a NamedTuple of the form (scc=scc, mm=mm). The same keyword arguments from the `compute_scc` function are available for the `compute_scc_mm` function. Example:
@@ -91,7 +93,7 @@ marginal_temp = result.mm[:ClimateTemperature, :rt_realizedtemperature]  # margi
 
 ### Pulse Size Details
 
-By default, MimiPAGE2009 will calculate the SCC using a marginal emissions pulse of 100_000 metric tonnes of CO2 spread over the years in the period following `year`.  Regardless of this pulse size, the SC will be returned in units of dollars per ton.  This choice of pulse size and duration is a decision made based on experiments with stability of results and moving from continuous to discretized equations, and can be found described further in the literature around PAGE.
+By default, MimiPAGE2009 will calculate the SCC using a marginal emissions pulse of 100_000 metric megatonnes of CO2 (Mtonne CO2) spread over the years in the period following `year`.  Regardless of this pulse size, the SC will be returned in units of dollars per ton.  This choice of pulse size and duration is a decision made based on experiments with stability of results and moving from continuous to discretized equations, and can be found described further in the literature around PAGE.
 
 If you wish to alter this pulse size, it is an optional keyword argument to the  `compute_scc` function where `pulse_size` controls the size of the marginal emission pulse. For a deeper dive into the machinery of this function, see the forum conversation [here](https://forum.mimiframework.org/t/mimifund-emissions-pulse/153/9) and the docstrings in `compute_scc.jl`.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ marginal_temp = result.mm[:ClimateTemperature, :rt_realizedtemperature]  # margi
 
 ### Pulse Size Details
 
-By default, MimiPAGE2009 will calculate the SCC using a marginal emissions pulse of 100_000 metric megatonnes of CO2 (Mtonne CO2) spread over the years in the period following `year`.  Regardless of this pulse size, the SC will be returned in units of dollars per ton.  This choice of pulse size and duration is a decision made based on experiments with stability of results and moving from continuous to discretized equations, and can be found described further in the literature around PAGE.
+By default, MimiPAGE2009 will calculate the SCC using a marginal emissions pulse of 100_000 metric megatonnes of CO2 (Mtonne CO2) spread over the years in the period following `year`.  Regardless of this pulse size, the SCC will be returned in units of dollars per ton since it is normalized over this pulse size.  This choice of pulse size and duration is a decision made based on experiments with stability of results and moving from continuous to discretized equations, and can be found described further in the literature around PAGE.
 
 If you wish to alter this pulse size, it is an optional keyword argument to the  `compute_scc` function where `pulse_size` controls the size of the marginal emission pulse. For a deeper dive into the machinery of this function, see the forum conversation [here](https://forum.mimiframework.org/t/mimifund-emissions-pulse/153/9) and the docstrings in `compute_scc.jl`.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ marginal_temp = result.mm[:ClimateTemperature, :rt_realizedtemperature]  # margi
 
 ### Pulse Size Details
 
-By default, MimiPAGE2009 will calculate the SCC using a marginal emissions pulse of 100_000 metric megatonnes of CO2 (Mtonne CO2) spread over the years in the period following `year`.  Regardless of this pulse size, the SCC will be returned in units of dollars per ton since it is normalized over this pulse size.  This choice of pulse size and duration is a decision made based on experiments with stability of results and moving from continuous to discretized equations, and can be found described further in the literature around PAGE.
+By default, MimiPAGE2009 will calculate the SCC using a marginal emissions pulse of 100_000 metric megatonnes of CO2 (Mtonne CO2) spread over the years before and after `year`.  Regardless of this pulse size, the SCC will be returned in units of dollars per ton since it is normalized over this pulse size.  This choice of pulse size and duration is a decision made based on experiments with stability of results and moving from continuous to discretized equations, and can be found described further in the literature around PAGE.
 
 If you wish to alter this pulse size, it is an optional keyword argument to the  `compute_scc` function where `pulse_size` controls the size of the marginal emission pulse. For a deeper dive into the machinery of this function, see the forum conversation [here](https://forum.mimiframework.org/t/mimifund-emissions-pulse/153/9) and the docstrings in `compute_scc.jl`.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ scc = MimiPAGE2009.compute_scc(m, year=2020)    # compute the scc from the modif
 ```
 The first argument to the `compute_scc` function is a MimiPAGE2009 model, and it is an optional argument. If no model is provided, the default MimiPAGE2009 model will be used. 
 There are also other keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
-Note that a pulse "in 2020" produces a gradual increase from 2015-2020 (or whatever the next period is), followed by a gradual decrease in emissions from 2020-2030 (or whatever that following period is). Emissions are linearly interpolated between the points given by the years.
+Note that a pulse "in 2020" produces a gradual increase from 2015-2020 (or whatever the preceeding period is), followed by a gradual decrease in emissions from 2020-2030 (or whatever that following period is). Emissions are linearly interpolated between the points given by the years.
 ```
 compute_scc(
     m = get_model(),  # if no model provided, will use the default MimiPAGE2009 model

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ scc = MimiPAGE2009.compute_scc(m, year=2020)    # compute the scc from the modif
 ```
 The first argument to the `compute_scc` function is a MimiPAGE2009 model, and it is an optional argument. If no model is provided, the default MimiPAGE2009 model will be used. 
 There are also other keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
+Note that a pulse "in 2020" produces a gradual increase from 2015-2020 (or whatever the next period is), followed by a gradual decrease in emissions from 2020-2030 (or whatever that following period is). Emissions are linearly interpolated between the points given by the years.
 ```
 compute_scc(
     m = get_model(),  # if no model provided, will use the default MimiPAGE2009 model

--- a/docs/src/model-structure.md
+++ b/docs/src/model-structure.md
@@ -78,6 +78,7 @@ The components in this portion of Mimi-PAGE include:
 - Adaptation Costs (for each impact sector)
 - Total Abatement Costs
 - Total Adaptation Costs
+- Total Costs
 - Equity Weighting
 
 ### Functional Components of Mimi-PAGE

--- a/src/compute_scc.jl
+++ b/src/compute_scc.jl
@@ -48,8 +48,7 @@ end
 
     function run_timestep(p, v, d, t)
         if gettime(t) == p.pulse_year
-            # pulse is spread evently across the years within this period, thus 
-            # division by getperiodlength(p.pulse_year)
+            # pulse is applied to the years around this year, as a triangular distribution
             v.e_globalCO2emissions_adjusted[t] = p.e_globalCO2emissions[t] + p.pulse_size / getperiodlength(p.pulse_year)
         else
             v.e_globalCO2emissions_adjusted[t] = p.e_globalCO2emissions[t]

--- a/src/compute_scc.jl
+++ b/src/compute_scc.jl
@@ -68,7 +68,7 @@ end
         n::Union{Int,Nothing}=nothing,
         trials_output_filename::Union{String, Nothing} = nothing,
         seed::Union{Int, Nothing} = nothing
-    )
+        )
 
 Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiPAGE2009 model `m`. 
 If no model is provided, the default model from MimiPAGE2009.get_model() is used.
@@ -78,7 +78,7 @@ The discounting scheme can be specified by the `eta` and `prtp` parameters, whic
 and ptp_timepreference in the model. If no values are provided, the discount factors will be computed using the default 
 PAGE values of emuc_utilitiyconvexity=1.1666666667 and ptp_timepreference=1.0333333333.
 
-The size of the marginal emission defaults to 100_000 min metric megatonnes of CO2 (Mtonne CO2), and this 
+The size of the marginal emission defaults to 100_000 metric megatonnes of CO2 (Mtonne CO2), and this 
 pulse can be modified with the `pulse_size` keyword argument, in metric megatonnes of CO2 (Mtonne CO2)
 (this does not change the units of the returned value, which is always normalized by the
 `pulse_size` used). The pulse size is spread over all years in the timestep following `year`.
@@ -175,16 +175,18 @@ end
 
 
 """
-    compute_scc_mm(m::Model = get_model(); year::Union{Int, Nothing} = nothing, eta::Union{Float64, Nothing} = nothing, prtp::Union{Float64, Nothing} = nothing)
+    compute_scc_mm(m::Model = get_model(); year::Union{Int, Nothing} = nothing, eta::Union{Float64, Nothing} = nothing, prtp::Union{Float64, Nothing} = nothing, pulse_size = 100000.)
 
 Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
 Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiPAGE2009 model. 
 This pulse defaults to 100_000 metric megatonnes of CO2 (Mtonne CO2), and is spread over all years within the 
-period following `year`. If no model is provided, the default model from MimiPAGE2009.get_model() is used.
-Discounting scheme can be specified by the `eta` and `prtp` parameters, which will 
-update the values of emuc_utilitiyconvexity and ptp_timepreference in the model. 
-If no values are provided, the discount factors will be computed using the default 
-PAGE values of emuc_utilitiyconvexity=1.1666666667 and ptp_timepreference=1.0333333333.    
+period following `year`. The SCC will be returned in dollars per ton regardless of
+pulse size, because it is normalized over the pulse size. If no model is provided, 
+the default model from MimiPAGE2009.get_model() is used. Discounting scheme can be 
+specified by the `eta` and `prtp` parameters, which will  update the values of 
+emuc_utilitiyconvexity and ptp_timepreference in the model.  If no values are provided, 
+the discount factors will be computed using the default PAGE values of emuc_utilitiyconvexity=1.1666666667 
+and ptp_timepreference=1.0333333333.    
 """
 function compute_scc_mm(m::Model = get_model(); year::Union{Int, Nothing} = nothing, eta::Union{Float64, Nothing} = nothing, prtp::Union{Float64, Nothing} = nothing, pulse_size = 100000.)
     year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2020)`.") : nothing
@@ -215,7 +217,7 @@ function compute_scc_mm(m::Model = get_model(); year::Union{Int, Nothing} = noth
 end
 
 """
-    get_marginal_model(m::Model = get_model(); year::Union{Int, Nothing} = nothing)
+    get_marginal_model(m::Model = get_model(); year::Union{Int, Nothing} = nothing, pulse_size = 100000.)
 
 Returns a Mimi MarginalModel where the provided m is the base model, and the 
 marginal model has additional emissions of CO2 in year `year`. If no Model m is 

--- a/src/compute_scc.jl
+++ b/src/compute_scc.jl
@@ -48,7 +48,8 @@ end
 
     function run_timestep(p, v, d, t)
         if gettime(t) == p.pulse_year
-            # pulse is spread evently across the years within this period, thus division by getperiodlength(p.pulse_year)
+            # pulse is spread evently across the years within this period, thus 
+            # division by getperiodlength(p.pulse_year)
             v.e_globalCO2emissions_adjusted[t] = p.e_globalCO2emissions[t] + p.pulse_size / getperiodlength(p.pulse_year)
         else
             v.e_globalCO2emissions_adjusted[t] = p.e_globalCO2emissions[t]
@@ -77,8 +78,8 @@ The discounting scheme can be specified by the `eta` and `prtp` parameters, whic
 and ptp_timepreference in the model. If no values are provided, the discount factors will be computed using the default 
 PAGE values of emuc_utilitiyconvexity=1.1666666667 and ptp_timepreference=1.0333333333.
 
-The size of the marginal emission defaults to 100_000 metric tonnes of CO2, and this 
-pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of CO2 
+The size of the marginal emission defaults to 100_000 min metric megatonnes of CO2 (Mtonne CO2), and this 
+pulse can be modified with the `pulse_size` keyword argument, in metric megatonnes of CO2 (Mtonne CO2)
 (this does not change the units of the returned value, which is always normalized by the
 `pulse_size` used). The pulse size is spread over all years in the timestep following `year`.
 
@@ -178,7 +179,7 @@ end
 
 Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
 Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiPAGE2009 model. 
-This pulse defaults to 100_000 metric tonnes of CO2, and is spread over all years within the 
+This pulse defaults to 100_000 metric megatonnes of CO2 (Mtonne CO2), and is spread over all years within the 
 period following `year`. If no model is provided, the default model from MimiPAGE2009.get_model() is used.
 Discounting scheme can be specified by the `eta` and `prtp` parameters, which will 
 update the values of emuc_utilitiyconvexity and ptp_timepreference in the model. 
@@ -220,7 +221,7 @@ Returns a Mimi MarginalModel where the provided m is the base model, and the
 marginal model has additional emissions of CO2 in year `year`. If no Model m is 
 provided, the default model from MimiPAGE2009.get_model() is used as the base model.
 Note that the returned MarginalModel has already been run. The `pulse_size` defaults 
-to 100_000 metric tonnes of CO2, and is spread over all years within the 
+to 100_000 metric megatonnes of CO2 (Mtonne CO2), and is spread over all years within the 
 period following `year`.
 """
 function get_marginal_model(m::Model = get_model(); year::Union{Int, Nothing} = nothing, pulse_size = 100000.)

--- a/src/compute_scc.jl
+++ b/src/compute_scc.jl
@@ -81,7 +81,9 @@ PAGE values of emuc_utilitiyconvexity=1.1666666667 and ptp_timepreference=1.0333
 The size of the marginal emission defaults to 100_000 metric megatonnes of CO2 (Mtonne CO2), and this 
 pulse can be modified with the `pulse_size` keyword argument, in metric megatonnes of CO2 (Mtonne CO2)
 (this does not change the units of the returned value, which is always normalized by the
-`pulse_size` used). The pulse size is spread over all years in the timestep following `year`.
+`pulse_size` used). A pulse in `year` is actually a gradual increase throughout the timestep preceeding `year`, 
+followed by a gradual decrease in emissions in the timestep superseeding `year`. Emissions are linearly interpolated 
+between the points given by the years.
 
 By default, `n = nothing`, and a single value for the "best guess" social cost of CO2 is returned. If a positive 
 value for keyword `n` is specified, then a Monte Carlo simulation with sample size `n` will run, sampling from 
@@ -180,13 +182,15 @@ end
 Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
 Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiPAGE2009 model. 
 This pulse defaults to 100_000 metric megatonnes of CO2 (Mtonne CO2), and is spread over all years within the 
-period following `year`. The SCC will be returned in dollars per ton regardless of
-pulse size, because it is normalized over the pulse size. If no model is provided, 
-the default model from MimiPAGE2009.get_model() is used. Discounting scheme can be 
-specified by the `eta` and `prtp` parameters, which will  update the values of 
-emuc_utilitiyconvexity and ptp_timepreference in the model.  If no values are provided, 
-the discount factors will be computed using the default PAGE values of emuc_utilitiyconvexity=1.1666666667 
-and ptp_timepreference=1.0333333333.    
+period following `year`. A pulse in `year` is actually a gradual increase throughout the timestep preceeding `year`, 
+followed by a gradual decrease in emissions in the timestep superseeding `year`. Emissions are linearly interpolated 
+between the points given by the years.
+
+The SCC will be returned in dollars per ton regardless of pulse size, because it is normalized over the pulse size. 
+If no model is provided, the default model from MimiPAGE2009.get_model() is used. Discounting scheme can be 
+specified by the `eta` and `prtp` parameters, which will  update the values of emuc_utilitiyconvexity and 
+ptp_timepreference in the model.  If no values are provided, the discount factors will be computed using the 
+default PAGE values of emuc_utilitiyconvexity=1.1666666667 and ptp_timepreference=1.0333333333.    
 """
 function compute_scc_mm(m::Model = get_model(); year::Union{Int, Nothing} = nothing, eta::Union{Float64, Nothing} = nothing, prtp::Union{Float64, Nothing} = nothing, pulse_size = 100000.)
     year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2020)`.") : nothing


### PR DESCRIPTION
@jrising I'm doing some general cleanup and checks, and in response to #189 I added these comments and documentation.  I'll clean it up a bit more, this was my first pass, but let me know if this looks about right to you since it's done a bit differently than in other models.

In particular I'm trying to map units, and I believe the `pulse_size` is in mega tonnes (MTonne) since it gets added right into the emissions component that takes Mtonne.  Is that right?  In the Issue Cora says we wanted to interpret the `pulse_size` as metric tonnes, which is what we normally do for the other models.  Thoughts?

To handle: #189 and #183